### PR TITLE
Convert Backend Code to ES-6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 package-lock.json
+.env

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+.env
 
 # testing
 /coverage

--- a/dist-server/index.js
+++ b/dist-server/index.js
@@ -1,0 +1,25 @@
+"use strict";
+
+var _express = _interopRequireDefault(require("express"));
+
+var _database = _interopRequireDefault(require("./config/database"));
+
+var _routes = _interopRequireDefault(require("./config/routes"));
+
+var _cors = _interopRequireDefault(require("cors"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
+
+dotenv.config();
+var port = process.env.PORT || 3020;
+var app = (0, _express["default"])();
+(0, _database["default"])();
+var corsOptions = {
+  exposedHeaders: 'x-auth'
+};
+app.use((0, _cors["default"])(corsOptions));
+app.use(_express["default"].json());
+app.use('/', _routes["default"]);
+app.listen(port, function () {
+  console.log('listening on the port', port);
+});

--- a/index.js
+++ b/index.js
@@ -1,21 +1,22 @@
-const express = require('express')
-const setUpDB = require('./config/database')
-const router = require('./config/routes')
-const cors = require('cors')
+import express  from 'express';
+import setUpDB from './config/database';
+import router from './config/routes';
+import cors from 'cors';
 
-const port = 3020
-const app = express()
-setUpDB()
+dotenv.config();
+const port = process.env.PORT || 3020;
+const app = express();
+setUpDB();
 
 const corsOptions = {
-    exposedHeaders: 'x-auth',
+  exposedHeaders: 'x-auth',
 };
+
 app.use(cors(corsOptions))
 
 app.use(express.json())
 app.use('/', router)
 
 app.listen(port, () => {
-    console.log('listening on the port', port)
+  console.log('listening on the port', port)
 })
-

--- a/package.json
+++ b/package.json
@@ -6,19 +6,41 @@
   "scripts": {
     "start": "node index.js",
     "dev-server": "nodemon index.js",
-    "dev": "concurrently \"nodemon index.js\" \"cd client && npm start\"",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev-project": "concurrently \"nodemon index.js\" \"cd client && npm start\"",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "transpile": "babel ./index.js --out-dir dist-server",
+    "clean": "rimraf dist-server",
+    "build": "npm-run-all clean transpile",
+    "dev": "NODE_ENV=development npm-run-all build server",
+    "prod": "NODE_ENV=production npm-run-all build server",
+    "watch:dev": "nodemon"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@babel/cli": "^7.13.10",
+    "@babel/core": "^7.13.10",
+    "@babel/preset-env": "^7.13.10",
     "bcryptjs": "^2.4.3",
     "concurrently": "^5.1.0",
     "cors": "^2.8.5",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.19",
     "mongoose": "^5.9.1",
+    "nodemon": "^2.0.7",
+    "rimraf": "^3.0.2",
     "validator": "^12.2.0"
+  },
+  "babel": {
+    "presets": [
+      "@babel/preset-env"
+    ]
+  },
+  "nodemonConfig": { 
+    "exec": "npm run dev",
+    "watch": ["server/*", "public/*"],
+    "ignore": ["**/__tests__/**", "*.test.js", "*.spec.js"]
   }
 }


### PR DESCRIPTION
Added .env and some packages to convert the es5 code to es6.
// closing out this one because I figured out that how we can use import statements in Backend code and we can always use ES-6 or higher ES codes if we use higher node versions. If you want to use import statements, just add { type="modules" } in package.json